### PR TITLE
Add score penalties for parts of the string that don't match.

### DIFF
--- a/__tests__/calculateScore.spec.ts
+++ b/__tests__/calculateScore.spec.ts
@@ -11,16 +11,16 @@ describe("calculateScore", () => {
 
     it("Gives less points for a match without accents", () => {
 
-        expect(calculateScore("e", "é").score).toBeCloseTo(0.8);
+        expect(calculateScore("e", "é").score).toBeCloseTo(0.98);
 
-        expect(calculateScore("E", "É").score).toBeCloseTo(0.8);
+        expect(calculateScore("E", "É").score).toBeCloseTo(0.98);
     })
 
     it("Gives less points for a match with uppercase/lowercase inconsistency", () => {
 
-        expect(calculateScore("e", "E").score).toBeCloseTo(0.6);
+        expect(calculateScore("e", "E").score).toBeCloseTo(0.95);
 
-        expect(calculateScore("é", "É").score).toBeCloseTo(0.6);
+        expect(calculateScore("é", "É").score).toBeCloseTo(0.95);
     });
 
     it("Gives no points for no match", () => {

--- a/__tests__/calculateScore.spec.ts
+++ b/__tests__/calculateScore.spec.ts
@@ -2,58 +2,31 @@ import calculateScore from "../src/calculateScore"
 
 describe("calculateScore", () => {
     it("Gives maximum points for an exact match", () => {
-        expect(calculateScore({
-            inputCharacter: "A",
-            referenceCharacter: "A",
-        }).score).toEqual(1);
+        expect(calculateScore("A", "A").score).toEqual(1);
 
-        expect(calculateScore({
-            inputCharacter: "a",
-            referenceCharacter: "a",
-        }).score).toEqual(1);
+        expect(calculateScore("a", "a").score).toEqual(1);
 
-        expect(calculateScore({
-            inputCharacter: "é",
-            referenceCharacter: "é",
-        }).score).toEqual(1);
+        expect(calculateScore("é", "é").score).toEqual(1);
     });
 
     it("Gives less points for a match without accents", () => {
 
-        expect(calculateScore({
-            inputCharacter: "e",
-            referenceCharacter: "é",
-        }).score).toBeCloseTo(0.8);
+        expect(calculateScore("e", "é").score).toBeCloseTo(0.8);
 
-        expect(calculateScore({
-            inputCharacter: "E",
-            referenceCharacter: "É",
-        }).score).toBeCloseTo(0.8);
+        expect(calculateScore("E", "É").score).toBeCloseTo(0.8);
     })
 
     it("Gives less points for a match with uppercase/lowercase inconsistency", () => {
 
-        expect(calculateScore({
-            inputCharacter: "e",
-            referenceCharacter: "E",
-        }).score).toBeCloseTo(0.6);
+        expect(calculateScore("e", "E").score).toBeCloseTo(0.6);
 
-        expect(calculateScore({
-            inputCharacter: "é",
-            referenceCharacter: "É",
-        }).score).toBeCloseTo(0.6);
+        expect(calculateScore("é", "É").score).toBeCloseTo(0.6);
     });
 
     it("Gives no points for no match", () => {
 
-        expect(calculateScore({
-            inputCharacter: "A",
-            referenceCharacter: "c",
-        }).score).toEqual(0);
+        expect(calculateScore("A", "c").score).toEqual(0);
 
-        expect(calculateScore({
-            inputCharacter: "f",
-            referenceCharacter: "É",
-        }).score).toEqual(0);
+        expect(calculateScore("f", "É").score).toEqual(0);
     })
 })

--- a/__tests__/scoreStringSimilarity.spec.ts
+++ b/__tests__/scoreStringSimilarity.spec.ts
@@ -66,10 +66,23 @@ describe("scoreStringSimilarity", () => {
     })
 
     it("Penalizes a string that has tailing non-matching characters", () => {
-        const moreChars = scoreStringSimilarity("cde", "abcdefgh");
-        const lessChars = scoreStringSimilarity("cdea", "abcdefgh");
+        const matchingChars = scoreStringSimilarity("cde", "abcdefgh");
+        const nonMatchingChars = scoreStringSimilarity("cdea", "abcdefgh");
 
-        expect(moreChars.score).toBeGreaterThan(lessChars.score);
+        expect(matchingChars.score).toBeGreaterThan(nonMatchingChars.score);
+    })
+    it("Penalizes a string that has starting non-matching characters", () => {
+        const matchingChars = scoreStringSimilarity("cde", "abcdefgh");
+        const nonMatchingChars = scoreStringSimilarity("xcde", "abcdefgh");
+
+        expect(matchingChars.score).toBeGreaterThan(nonMatchingChars.score);
+    })
+
+    it("Gives a similar score penalty for non-matching characters in the start as in the end", () => {
+        const startMismatch = scoreStringSimilarity("xcde", "abcdefgh");
+        const endMismatch = scoreStringSimilarity("cdex", "abcdefgh");
+
+        expect(startMismatch.score).toBeCloseTo(endMismatch.score);
     })
 
 })

--- a/__tests__/scoreStringSimilarity.spec.ts
+++ b/__tests__/scoreStringSimilarity.spec.ts
@@ -26,6 +26,14 @@ describe("scoreStringSimilarity", () => {
         ]);
     });
 
+    it("Gives an higher score for small prefix matches than for large non-prefix matches", () => {
+        const prefixMatch = scoreStringSimilarity("abc", "abcdefghi");
+        const otherMatch = scoreStringSimilarity("bcd", "abcdefghi");
+
+
+        expect(prefixMatch.score).toBeGreaterThan(otherMatch.score);
+    })
+
     it("Gives a score of 0 for a non-match", () => {
         const match = scoreStringSimilarity("xy", "abcdefghi");
         expect(match.score).toBeCloseTo(0);

--- a/__tests__/scoreStringSimilarity.spec.ts
+++ b/__tests__/scoreStringSimilarity.spec.ts
@@ -65,4 +65,11 @@ describe("scoreStringSimilarity", () => {
         expect(contiguousMatch.score).toBeGreaterThan(nonContiguousMatch.score);
     })
 
+    it("Penalizes a string that has tailing non-matching characters", () => {
+        const moreChars = scoreStringSimilarity("cde", "abcdefgh");
+        const lessChars = scoreStringSimilarity("cdea", "abcdefgh");
+
+        expect(moreChars.score).toBeGreaterThan(lessChars.score);
+    })
+
 })

--- a/src/calculateScore.ts
+++ b/src/calculateScore.ts
@@ -1,12 +1,13 @@
-import { ScoreContext, ScoreResult, SimilarityOpts } from './types';
+import { ScoreResult, SimilarityOpts } from './types';
 import { normalizeSync as removeAccents } from 'normalize-diacritics';
 
 export default function calculateScore(
-    scoreContext: ScoreContext,
+    inputCharacter: string,
+    referenceCharacter: string,
     opts: SimilarityOpts = {}
 ): ScoreResult {
     // Exact match, including accents and case
-    if (scoreContext.inputCharacter === scoreContext.referenceCharacter) {
+    if (inputCharacter === referenceCharacter) {
         return {
             score: 1,
             match: true,
@@ -14,11 +15,11 @@ export default function calculateScore(
     }
 
     const inputChar = opts.keepAccents
-        ? scoreContext.inputCharacter
-        : removeAccents(scoreContext.inputCharacter);
+        ? inputCharacter
+        : removeAccents(inputCharacter);
     const referenceChar = opts.keepAccents
-        ? scoreContext.referenceCharacter
-        : removeAccents(scoreContext.referenceCharacter);
+        ? referenceCharacter
+        : removeAccents(referenceCharacter);
     // Exact match, including case
     if (inputChar === referenceChar) {
         return {

--- a/src/calculateScore.ts
+++ b/src/calculateScore.ts
@@ -23,14 +23,14 @@ export default function calculateScore(
     // Exact match, including case
     if (inputChar === referenceChar) {
         return {
-            score: 0.8,
+            score: 0.98,
             match: true,
         };
     }
     // Match, not including case
     if (inputChar.toLowerCase() === referenceChar.toLowerCase()) {
         return {
-            score: 0.6,
+            score: 0.95,
             match: true,
         };
     }

--- a/src/scoreStringSimilarity.ts
+++ b/src/scoreStringSimilarity.ts
@@ -49,6 +49,12 @@ export default function scoreStringSimilarity(
         referencePosition++;
     }
 
+    // Decrease score for non-matching characters
+    score -= Math.min(
+        score,
+        (inputData.length - inputPosition) / inputData.length
+    );
+
     // When we ran out of characters in the input string, we still need to add the last part of the reference to the matches
     if (referencePosition < referenceData.length) {
         chunks.push({

--- a/src/scoreStringSimilarity.ts
+++ b/src/scoreStringSimilarity.ts
@@ -1,13 +1,70 @@
 import { SimilarityOpts, SimilarityResult, MatchChunk } from './types';
 import calculateScore from './calculateScore';
 import combineChunks from './combineChunks';
+import debug from 'debug';
+
+const d = debug('xenit:finder-string-similarity-score');
+
+function scanForNextPosition(
+    inputData: string,
+    referenceData: string,
+    inputPosition: number,
+    referencePosition: number,
+    opts: SimilarityOpts
+) {
+    let bestPosition = {
+        inputPosition: inputData.length,
+        referencePosition: referenceData.length,
+    };
+    for (
+        let newReferencePosition = referencePosition;
+        newReferencePosition < referenceData.length;
+        newReferencePosition++
+    ) {
+        for (
+            let newInputPosition = inputPosition;
+            newInputPosition < inputData.length;
+            newInputPosition++
+        ) {
+            if (
+                newReferencePosition + newInputPosition <
+                bestPosition.inputPosition + bestPosition.referencePosition
+            ) {
+                const { match } = calculateScore(
+                    {
+                        inputCharacter: inputData[newInputPosition],
+                        referenceCharacter: referenceData[newReferencePosition],
+                    },
+                    opts
+                );
+                if (match) {
+                    bestPosition = {
+                        inputPosition: newInputPosition,
+                        referencePosition: newReferencePosition,
+                    };
+                }
+            }
+        }
+    }
+    return bestPosition;
+}
 
 export default function scoreStringSimilarity(
     inputData: string,
     referenceData: string,
     opts: SimilarityOpts = {}
 ): SimilarityResult {
+    d(
+        'Scoring similarity for input %o and reference %o',
+        inputData,
+        referenceData
+    );
     if (inputData.length > referenceData.length) {
+        d(
+            'Input %o is longer than reference %o, returning score of 0',
+            inputData,
+            referenceData
+        );
         // If input is longer than the reference to compare to, it does not match
         return {
             score: 0,
@@ -22,8 +79,24 @@ export default function scoreStringSimilarity(
 
     let score = 0;
     const chunks: MatchChunk[] = [];
-    let inputPosition = 0;
-    let referencePosition = 0;
+
+    let { inputPosition, referencePosition } = scanForNextPosition(
+        inputData,
+        referenceData,
+        0,
+        0,
+        opts
+    );
+
+    if (referencePosition > 0) {
+        chunks.push({
+            text: referenceData.slice(0, referencePosition),
+            matched: false,
+        });
+    }
+
+    let totalSkippedInputCharacters = inputPosition;
+    let totalSkippedReferenceCharacters = referencePosition;
 
     while (
         inputPosition < inputData.length &&
@@ -39,20 +112,47 @@ export default function scoreStringSimilarity(
 
         score += currentScore;
 
-        chunks.push({
-            text: referenceData[referencePosition],
-            matched: match,
-        });
         if (match) {
+            chunks.push({
+                text: referenceData[referencePosition],
+                matched: true,
+            });
             inputPosition++;
+            referencePosition++;
+        } else {
+            const nextPosition = scanForNextPosition(
+                inputData,
+                referenceData,
+                inputPosition,
+                referencePosition,
+                opts
+            );
+
+            chunks.push({
+                text: referenceData.slice(
+                    referencePosition,
+                    nextPosition.referencePosition
+                ),
+                matched: false,
+            });
+
+            totalSkippedInputCharacters +=
+                nextPosition.inputPosition - inputPosition;
+            totalSkippedReferenceCharacters +=
+                nextPosition.referencePosition - referencePosition;
+
+            inputPosition = nextPosition.inputPosition;
+            referencePosition = nextPosition.referencePosition;
         }
-        referencePosition++;
     }
 
-    // Decrease score for non-matching characters
-    score -= Math.min(
-        score,
-        (inputData.length - inputPosition) / inputData.length
+    totalSkippedInputCharacters += inputData.length - inputPosition;
+    totalSkippedReferenceCharacters += referenceData.length - referencePosition;
+
+    // Decrease score for skipped characters
+    score *= Math.pow(
+        0.99,
+        totalSkippedInputCharacters + totalSkippedReferenceCharacters
     );
 
     // When we ran out of characters in the input string, we still need to add the last part of the reference to the matches
@@ -77,8 +177,18 @@ export default function scoreStringSimilarity(
         combinedChunks.filter(c => c.matched).length - 1
     );
 
+    score *= nonContiguousPenalty;
+
+    score /= referenceData.length + 1; // +1 to counterbalance score boost for start of string match
+
+    d(
+        'Final score comparing input %o to reference %o: %d',
+        inputData,
+        referenceData,
+        score
+    );
     return {
-        score: (score * nonContiguousPenalty) / (referenceData.length + 1), // +1 to counterbalance score boost for start of string match
+        score: score,
         chunks: combinedChunks,
     };
 }

--- a/src/scoreStringSimilarity.ts
+++ b/src/scoreStringSimilarity.ts
@@ -11,11 +11,11 @@ function scanForNextPosition(
     inputPosition: number,
     referencePosition: number,
     opts: SimilarityOpts
-) {
-    let bestPosition = {
-        inputPosition: inputData.length,
-        referencePosition: referenceData.length,
-    };
+): [number, number] {
+    let bestPosition: [number, number] = [
+        inputData.length,
+        referenceData.length,
+    ];
     for (
         let newReferencePosition = referencePosition;
         newReferencePosition < referenceData.length;
@@ -28,20 +28,15 @@ function scanForNextPosition(
         ) {
             if (
                 newReferencePosition + newInputPosition <
-                bestPosition.inputPosition + bestPosition.referencePosition
+                bestPosition[0] + bestPosition[1]
             ) {
                 const { match } = calculateScore(
-                    {
-                        inputCharacter: inputData[newInputPosition],
-                        referenceCharacter: referenceData[newReferencePosition],
-                    },
+                    inputData[newInputPosition],
+                    referenceData[newReferencePosition],
                     opts
                 );
                 if (match) {
-                    bestPosition = {
-                        inputPosition: newInputPosition,
-                        referencePosition: newReferencePosition,
-                    };
+                    bestPosition = [newInputPosition, newReferencePosition];
                 }
             }
         }
@@ -80,7 +75,7 @@ export default function scoreStringSimilarity(
     let score = 0;
     const chunks: MatchChunk[] = [];
 
-    let { inputPosition, referencePosition } = scanForNextPosition(
+    let [inputPosition, referencePosition] = scanForNextPosition(
         inputData,
         referenceData,
         0,
@@ -103,10 +98,8 @@ export default function scoreStringSimilarity(
         referencePosition < referenceData.length
     ) {
         const { score: currentScore, match } = calculateScore(
-            {
-                inputCharacter: inputData[inputPosition],
-                referenceCharacter: referenceData[referencePosition],
-            },
+            inputData[inputPosition],
+            referenceData[referencePosition],
             opts
         );
 
@@ -120,7 +113,10 @@ export default function scoreStringSimilarity(
             inputPosition++;
             referencePosition++;
         } else {
-            const nextPosition = scanForNextPosition(
+            const [
+                nextInputPosition,
+                nextReferencePosition,
+            ] = scanForNextPosition(
                 inputData,
                 referenceData,
                 inputPosition,
@@ -131,18 +127,17 @@ export default function scoreStringSimilarity(
             chunks.push({
                 text: referenceData.slice(
                     referencePosition,
-                    nextPosition.referencePosition
+                    nextReferencePosition
                 ),
                 matched: false,
             });
 
-            totalSkippedInputCharacters +=
-                nextPosition.inputPosition - inputPosition;
+            totalSkippedInputCharacters += nextInputPosition - inputPosition;
             totalSkippedReferenceCharacters +=
-                nextPosition.referencePosition - referencePosition;
+                nextReferencePosition - referencePosition;
 
-            inputPosition = nextPosition.inputPosition;
-            referencePosition = nextPosition.referencePosition;
+            inputPosition = nextInputPosition;
+            referencePosition = nextReferencePosition;
         }
     }
 


### PR DESCRIPTION
Also skip some input characters when they match nowhere in the reference string, because typos and mistakes can happen